### PR TITLE
enable multi core proving

### DIFF
--- a/vite-project/vite.config.js
+++ b/vite-project/vite.config.js
@@ -40,6 +40,16 @@ export default defineConfig(({ command }) => {
                     hook: 'buildStart',
                 }),
                 command === 'serve' ? wasmContentTypePlugin : [],
+                {
+                    name: "configure-response-headers",
+                    configureServer: (server) => {
+                    server.middlewares.use((_req, res, next) => {
+                        res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+                        res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+                        next();
+                    });
+                    },
+                },
             ],
         };
     }


### PR DESCRIPTION
# Description

## Problem
The berrenberg backend uses @noir/bb.js which need cross origin Isolation to enable multi core proving
It checks if `window.crossOriginIsolated === true` and if `SharedArrayBuffer` is defined.  However these are disabled due to a workaround involving the specter meltdown bug. This only effects the browser.
  
The only way to re-enable mulit-core proving is to set the appropriate CORS headers:
```js
"Cross-Origin-Embedder-Policy":"require-corp",
"Cross-Origin-Opener-Policy":"same-origin"
```
  

Resolves https://github.com/noir-lang/tiny-noirjs-app/issues/9
## Summary\*
Some CORS headers need to be set in order to enable multi-core for proving.


## Additional Context
It's not going to speed up the hello world circuit here ofc. But maybe it helps someone that got stuck on this (like me :p)

More info about SharedArrayBuffer here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements

bb.js check here: https://github.com/AztecProtocol/aztec-packages/blob/master/barretenberg/ts/src/barretenberg_wasm/helpers/browser/index.ts#L3



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
