### PR TITLE
chore: fix vite config to support firefox

### DIFF
--- a/vite-project/vite.config.js
+++ b/vite-project/vite.config.js
@@ -22,9 +22,6 @@ const wasmContentTypePlugin = {
 export default defineConfig({
     build: {
         target: 'esnext',
-        rollupOptions: {
-            external: ['@aztec/bb.js']
-        }
     },
     optimizeDeps: {
         esbuildOptions: {
@@ -41,8 +38,13 @@ export default defineConfig({
         {
             name: "configure-response-headers",
             configureServer: (server) => {
-            server.middlewares.use((_req, res, next) => {
-                res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+            server.middlewares.use((req, res, next) => {
+                const userAgent = req.headers['user-agent'];
+                // Firefox doesn't support multi-threaded WASM when the binary is inside JS
+                if(typeof userAgent === 'string' && userAgent.indexOf('Firefox') === -1) {
+                    res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+                    res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+                }
                 next();
             });
             },

--- a/vite-project/vite.config.js
+++ b/vite-project/vite.config.js
@@ -44,7 +44,6 @@ export default defineConfig(({ command }) => {
                     name: "configure-response-headers",
                     configureServer: (server) => {
                     server.middlewares.use((_req, res, next) => {
-                        res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
                         res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
                         next();
                     });

--- a/vite-project/vite.config.js
+++ b/vite-project/vite.config.js
@@ -19,39 +19,33 @@ const wasmContentTypePlugin = {
     },
 };
 
-export default defineConfig(({ command }) => {
-    if (command === 'serve') {
-        return {
-            build: {
-                target: 'esnext',
-                rollupOptions: {
-                    external: ['@aztec/bb.js']
-                }
+export default defineConfig({
+    build: {
+        target: 'esnext',
+        rollupOptions: {
+            external: ['@aztec/bb.js']
+        }
+    },
+    optimizeDeps: {
+        esbuildOptions: {
+            target: 'esnext'
+        }
+    },
+    plugins: [
+        copy({
+            targets: [{ src: 'node_modules/**/*.wasm', dest: 'node_modules/.vite/dist' }],
+            copySync: true,
+            hook: 'buildStart',
+        }),
+        wasmContentTypePlugin,
+        {
+            name: "configure-response-headers",
+            configureServer: (server) => {
+            server.middlewares.use((_req, res, next) => {
+                res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+                next();
+            });
             },
-            optimizeDeps: {
-                esbuildOptions: {
-                    target: 'esnext'
-                }
-            },
-            plugins: [
-                copy({
-                    targets: [{ src: 'node_modules/**/*.wasm', dest: 'node_modules/.vite/dist' }],
-                    copySync: true,
-                    hook: 'buildStart',
-                }),
-                command === 'serve' ? wasmContentTypePlugin : [],
-                {
-                    name: "configure-response-headers",
-                    configureServer: (server) => {
-                    server.middlewares.use((_req, res, next) => {
-                        res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-                        next();
-                    });
-                    },
-                },
-            ],
-        };
-    }
-
-    return {};
+        },
+    ],
 });


### PR DESCRIPTION
# Description

## Problem\*

Resolves #11 

## Summary\*

This fixes the wasm loading on Firefox for me.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
